### PR TITLE
Update m3 calculation

### DIFF
--- a/gazpar.py
+++ b/gazpar.py
@@ -157,6 +157,8 @@ def update_counters(session, start_date, end_date):
         try :
             #volume = round(int(conso)/int(coeffConversion),2)
             index = index + conso
+            volume *= 100
+            indexm3 *= 100
         except TypeError:
             print(req_date, conso, index, "Invalid Entry")
             continue;


### PR DESCRIPTION
Dz index is in liter : USAGE= Gas usage in liter (1000 liter = 1 m³) 
Don't know why it's a factor 100 instead of 1000 but works with 100 and is ok with GRDF excel export.